### PR TITLE
サイトのベースパスを動的に設定し、関連するリンクを更新

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,13 @@
 import {
   defineConfig
 } from 'astro/config';
+import {
+  BASE_PATH
+} from './src/assets/js/lib/config';
 
 // https://astro.build/config
 export default defineConfig({
-  base: '/animezumi/',
+  base: BASE_PATH,
   outDir: 'dist/animezumi/',
   build: {
     assets: '_astro'

--- a/src/assets/js/lib/config.ts
+++ b/src/assets/js/lib/config.ts
@@ -1,0 +1,1 @@
+export const BASE_PATH = '/animezumi/';

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -1,13 +1,14 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../assets/js/lib/config';
+
 const navItems = [
   {
     label: 'TOP',
-    href: `${base}`
+    href: `${BASE_PATH}`
   },
   {
     label: 'アニメーション集',
-    href: `${base}animations`
+    href: `${BASE_PATH}animations`
   },
 ]
 

--- a/src/pages/animations/float.astro
+++ b/src/pages/animations/float.astro
@@ -1,5 +1,5 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../../assets/js/lib/config';
 import Layout from '../../layouts/Layout.astro';
 import { Code } from 'astro:components';
 
@@ -62,7 +62,7 @@ const cssExample = `.float-animation {
     </section>
 
     <div class="animation__back">
-      <a href={`${base}animations`}>アニメーション一覧に戻る</a>
+      <a href={`${BASE_PATH}animations`}>アニメーション一覧に戻る</a>
     </div>
   </div>
 </Layout>

--- a/src/pages/animations/index.astro
+++ b/src/pages/animations/index.astro
@@ -1,5 +1,5 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../../assets/js/lib/config';
 import Layout from '../../layouts/Layout.astro';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
@@ -47,7 +47,7 @@ export const animations = [
 			<ul class="animation-grid">
 				{animations.map((item) => (
 					<li class="animation-card">
-						<a href={`${base}${item.link}`}>
+						<a href={`${BASE_PATH}${item.link}`}>
 							<div class="animation-card__visual">
 								{(() => {
 									const Component = componentMap[item.component as keyof typeof componentMap];
@@ -61,7 +61,7 @@ export const animations = [
 				))}
 			</ul>
 			<div class="animation__back">
-				<a href={`${base}`}>トップに戻る</a>
+				<a href={`${BASE_PATH}`}>トップに戻る</a>
 			</div>
 		</div>
 	</section>

--- a/src/pages/animations/morph.astro
+++ b/src/pages/animations/morph.astro
@@ -1,5 +1,5 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../../assets/js/lib/config';
 import Layout from '../../layouts/Layout.astro';
 import { Code } from 'astro:components';
 
@@ -135,7 +135,7 @@ const cssExample = `.morph-animation {
     </section>
 
     <div class="animation__back">
-      <a href={`${base}animations`}>アニメーション一覧に戻る</a>
+      <a href={`${BASE_PATH}animations`}>アニメーション一覧に戻る</a>
     </div>
   </div>
 

--- a/src/pages/animations/pulse.astro
+++ b/src/pages/animations/pulse.astro
@@ -1,5 +1,5 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../../assets/js/lib/config';
 import Layout from '../../layouts/Layout.astro';
 import { Code } from 'astro:components';
 
@@ -55,7 +55,7 @@ const cssExample = `.pulse-animation {
     </section>
 
     <div class="animation__back">
-      <a href={`${base}animations`}>アニメーション一覧に戻る</a>
+      <a href={`${BASE_PATH}animations`}>アニメーション一覧に戻る</a>
     </div>
   </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-const base = Astro.url.pathname;
+import { BASE_PATH } from '../assets/js/lib/config';
 import Layout from '../layouts/Layout.astro';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
@@ -50,7 +50,7 @@ const componentMap = {
 			<ul class="animation-grid">
 				{animations && animations.map((item) => (
 					<li class="animation-card">
-						<a href={`${base}${item.link}`}>
+						<a href={`${BASE_PATH}${item.link}`}>
 							<div class="animation-card__visual">
 								{(() => {
 									const Component = componentMap[item.component as keyof typeof componentMap];
@@ -64,7 +64,7 @@ const componentMap = {
 				))}
 			</ul>
 			<div class="animation-more">
-				<a href={`${base}animations`} class="button button--outline">もっと見る</a>
+				<a href={`${BASE_PATH}animations`} class="button button--outline">もっと見る</a>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
- astro.config.mjsでBASE_PATHを使用してベースパスを設定。
- 各コンポーネントでbase変数をBASE_PATHに置き換え、リンクの一貫性を向上。